### PR TITLE
Add kubernetes.civo.com/protocol annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Read More: https://www.civo.com/learn/managing-external-load-balancers-on-civo
 | kubernetes.civo.com/firewall-id | If provided, an existing Firewall will be used. | 03093EF6-31E6-48B1-AB1D-152AC3A8C90A |
 | kubernetes.civo.com/loadbalancer-enable-proxy-protocol | If set, a proxy-protocol header will be sent via the load balancer. <br /><br />NB: This requires support from the Service End Points within the cluster. | send-proxy<br />send-proxy-v2 |
 | kubernetes.civo.com/loadbalancer-algorithm | Custom the algorithm the external load balancer uses | round_robin<br />least_connections |
-|kubernetes.civo.com/ipv4-address| If set, LoadBalancer will have the mentioned IP as the public IP. Please note: the reserved IP should be present in the account before claiming it. | 10.0.0.20<br/> my-reserved-ip |
+| kubernetes.civo.com/ipv4-address | If set, LoadBalancer will have the mentioned IP as the public IP. Please note: the reserved IP should be present in the account before claiming it. | 10.0.0.20<br/> my-reserved-ip |
+| kubernetes.civo.com/protocol | If set, this will override the protocol set on the svc with this | http<br />tcp |
 
 ### Load Balancer Status Annotations
 

--- a/cloud-controller-manager/civo/loadbalancer_test.go
+++ b/cloud-controller-manager/civo/loadbalancer_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/civo/civogo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	cloudprovider "k8s.io/cloud-provider"
@@ -665,7 +666,7 @@ func TestEnsureLoadBalancer(t *testing.T) {
 	}
 }
 
-//TestUpdateLoadBalancer tests the update of a load balancer
+// TestUpdateLoadBalancer tests the update of a load balancer
 func TestUpdateLoadBalancer(t *testing.T) {
 	g := NewWithT(t)
 	tests := []struct {
@@ -794,7 +795,7 @@ func TestUpdateLoadBalancer(t *testing.T) {
 	}
 }
 
-//TestEnsureLoadBalancerDeleted tests the ensureLoadBalancerDeleted function
+// TestEnsureLoadBalancerDeleted tests the ensureLoadBalancerDeleted function
 func TestEnsureLoadBalancerDeleted(t *testing.T) {
 	g := NewGomegaWithT(t)
 	service := &corev1.Service{
@@ -855,4 +856,28 @@ func TestEnsureLoadBalancerDeleted(t *testing.T) {
 
 	err = lb.EnsureLoadBalancerDeleted(context.Background(), "test", service)
 	g.Expect(err).To(BeNil())
+}
+
+func TestGetProtocol(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	tests := map[string]struct {
+		Annotation string
+		Result     string
+	}{
+		"No Annotation Set":        {Annotation: "", Result: "TCP"},
+		"Annotation Set":           {Annotation: "HTTP", Result: "HTTP"},
+		"Lowercase Annotation Set": {Annotation: "http", Result: "HTTP"},
+	}
+	svc := &v1.Service{}
+	port := v1.ServicePort{Protocol: corev1.ProtocolTCP}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			svc.Annotations = map[string]string{annotationCivoProtocol: test.Annotation}
+			res := getProtocol(svc, port)
+			g.Expect(res).Should(Equal(test.Result))
+		})
+
+	}
 }


### PR DESCRIPTION
k8s versions > 1.22 do not allow the protocol of "HTTP" to be used. This PR adds an annotation to allow for "HTTP" to be used and a test to ensure that the `x-forward-for` header is still found