### PR TITLE
Add external IP when present

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,4 @@
 CIVO_API_KEY=
-CIVO_REGION=STAGING
-CIVO_API_URL=https://api-staging.civo.com
+CIVO_REGION=lon1
+CIVO_API_URL=https://api.civo.com
 CIVO_CLUSTER_ID=

--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,4 @@
 CIVO_API_KEY=
+CIVO_REGION=STAGING
+CIVO_API_URL=https://api-staging.civo.com
+CIVO_CLUSTER_ID=

--- a/cloud-controller-manager/civo/instances.go
+++ b/cloud-controller-manager/civo/instances.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/civo/civo-cloud-controller-manager/cloud-controller-manager/pkg/utils"
+	"github.com/civo/civogo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -34,11 +35,19 @@ func (i *instances) NodeAddresses(ctx context.Context, name types.NodeName) ([]v
 		return nil, err
 	}
 
-	a := v1.NodeAddress{Type: "InternalIP", Address: instance.PrivateIP}
-
 	// Return Public and Private Addresses
-	return []v1.NodeAddress{a}, nil
+	return getAddressessFromCivoInstance(instance), nil
 
+}
+
+func getAddressessFromCivoInstance(instance civogo.Instance) []v1.NodeAddress {
+	nodeAdresses := make([]v1.NodeAddress, 0, 2)
+	nodeAdresses = append(nodeAdresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: instance.PrivateIP})
+	if instance.PublicIP != "" {
+		nodeAdresses = append(nodeAdresses, v1.NodeAddress{Type: v1.NodeExternalIP, Address: instance.PublicIP})
+	}
+
+	return nodeAdresses
 }
 
 // NodeAddressesByProviderID returns the addresses of the specified instance.
@@ -53,10 +62,8 @@ func (i *instances) NodeAddressesByProviderID(ctx context.Context, providerID st
 		return nil, err
 	}
 
-	a := v1.NodeAddress{Type: "InternalIP", Address: instance.PrivateIP}
-
 	// Return Public and Private Addresses
-	return []v1.NodeAddress{a}, nil
+	return getAddressessFromCivoInstance(instance), nil
 }
 
 // InstanceID returns the cloud provider ID of the node with the specified NodeName.

--- a/cloud-controller-manager/civo/instances_test.go
+++ b/cloud-controller-manager/civo/instances_test.go
@@ -78,6 +78,7 @@ func TestNodeAddressesByProviderID(t *testing.T) {
 			ID:        "acb5cbd0-ef7f-4edd-8a51-005940fdb7a8",
 			Hostname:  "test-node",
 			PrivateIP: "192.168.11.11",
+			PublicIP:  "127.0.0.101",
 		},
 	}
 	expected :=
@@ -85,6 +86,10 @@ func TestNodeAddressesByProviderID(t *testing.T) {
 			{
 				Type:    corev1.NodeInternalIP,
 				Address: "192.168.11.11",
+			},
+			corev1.NodeAddress{
+				Type:    corev1.NodeExternalIP,
+				Address: "127.0.0.101",
 			},
 		}
 	clusterStore := []civogo.KubernetesCluster{


### PR DESCRIPTION
We need to support external IP on "kubectl get nodes" output and this MR enables that