### PR TITLE
Add priority class to deployment yaml

### DIFF
--- a/doc/yaml/ccm-install.yaml
+++ b/doc/yaml/ccm-install.yaml
@@ -62,6 +62,7 @@ spec:
         app: civo-ccm
         role: civo-ccm
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccount: civo-ccm-sa
       dnsPolicy: Default
       hostNetwork: true


### PR DESCRIPTION
Set the priority class on the deployment so other pods are evicted earlier in the event the underlying nodes start to run out of resources.