### PR TITLE
Add E2E test for proxy protocol

### DIFF
--- a/cloud-controller-manager/civo/cloud.go
+++ b/cloud-controller-manager/civo/cloud.go
@@ -8,13 +8,11 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 )
 
-const (
-	// ProviderName is the name of the provider.
-	ProviderName string = "civo"
+// ProviderName is the name of the provider.
+const ProviderName string = "civo"
 
-	// CCMVersion is the version of the CCM.
-	CCMVersion string = "dev"
-)
+// CCMVersion is the version of the CCM.
+var CCMVersion string = "dev"
 
 var (
 	// APIURL is the URL of the Civo API.

--- a/e2e/loadbalancer_test.go
+++ b/e2e/loadbalancer_test.go
@@ -173,7 +173,7 @@ func TestLoadbalancerProxyProtocol(t *testing.T) {
 		// Service deletion takes time, so make sure to check until it is fully deleted just in case.
 		g.Eventually(func() error {
 			return e2eTest.tenantClient.Get(ctx, client.ObjectKeyFromObject(svc), svc)
-		}, "2m", "5s").ShouldNot(BeNil())
+		}, "2m", "5s").ShouldNot(HaveOccurred())
 	})
 
 	g.Eventually(func() string {


### PR DESCRIPTION
## WHAT

Add an E2E test for the case when the PROXY protocol flag is enabled.

## WHY

Closes #38 , #9


In the previous [PR](https://github.com/civo/civo-cloud-controller-manager/pull/37), the E2E test `TestLoadbalancerHTTPForwardFor` was removed. Since we now support the PROXY protocol flag, we need a test case that covers the scenario where proxy_flag is enabled.

## Test

1. Create Reserved IP Addresses in the UI dashboard.
    - (Note: Pre-creation may not be strictly necessary, but I used an existing Reserved IP in my environment: `ccm-e2e-test-ip`)
2. Configure the `.env` file for E2E test execution:
    - Place it at the project root. Example:
    ```
    CIVO_API_KEY={TODO}
    CIVO_REGION=lon1
    CIVO_API_URL=https://api.civo.com
    ```
4. Run the E2E tests with:
```sh
go test -count=1 -timeout 20m -v ./e2e/...
```

## Test Result

- ✅ All E2E tests passed.

```
.....
Waiting for auto-assigned IP to be attached to LB
I0414 18:31:32.199711 3022299 event.go:307] "Event occurred" object="default/echo-pods" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuredLoadBalancer" message="Ensured load balancer"
I0414 18:31:32.464041 3022299 event.go:307] "Event occurred" object="default/echo-pods" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuringLoadBalancer" message="Ensuring load balancer"
I0414 18:31:35.226323 3022299 event.go:307] "Event occurred" object="default/echo-pods" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuredLoadBalancer" message="Ensured load balancer"
I0414 18:31:39.170097 3022299 event.go:307] "Event occurred" object="default/echo-pods" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="DeletingLoadBalancer" message="Deleting load balancer"
I0414 18:31:41.512497 3022299 event.go:307] "Event occurred" object="default/echo-pods" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="DeletedLoadBalancer" message="Deleted load balancer"
--- PASS: TestLoadbalancerReservedIP (42.07s)
PASS
Attempting Test Cleanup
Deleting Cluster: {MASK}
ok      github.com/civo/civo-cloud-controller-manager/e2e       293.179s
```

- 🧹 All test resources were successfully cleaned up:

```
❯ kubectl get svc echo-pods -n default --kubeconfig kubeconfig
Error from server (NotFound): services "echo-pods" not found

❯ kubectl get deploy echo-pods -n default --kubeconfig kubeconfig
Error from server (NotFound): deployments.apps "echo-pods" not found
```

## REF

https://github.com/civo/civo-cloud-controller-manager/pull/37#discussion_r2033919488

---

The civogo library update was already handled in the previous [PR](https://github.com/civo/civo-cloud-controller-manager/pull/37/files#r2031163617).
